### PR TITLE
Fix data to be string instead of bytestring for Python3

### DIFF
--- a/confluence_tool/cli/cli.py
+++ b/confluence_tool/cli/cli.py
@@ -188,6 +188,7 @@ def _handle_method(method, config, data=None, json=None):
         if config.get('stream'):
             _len = 0
             for data in result.iter_content(chunk_size=1024*1024):
+                data = data.decode("utf-8")
                 outstream.write(data)
 
                 _len += len(data)

--- a/confluence_tool/page.py
+++ b/confluence_tool/page.py
@@ -2,12 +2,20 @@ import six
 
 if six.PY3:
     from html.parser import HTMLParser
+    from html import unescape
 else:
     from HTMLParser import HTMLParser
 
 htmlparser = HTMLParser()
 
 from lxml.etree import XMLSyntaxError
+
+# PY3
+def _unescape(value):
+    if six.PY3:
+        return unescape(value)
+    else:
+        return HTMLParser.unescape(value)
 
 import logging
 log = logging.getLogger('confluence-tool.page')
@@ -24,13 +32,13 @@ class Page(object):
                 body = body['storage']
 
                 log.debug("body: %s", body['value'])
-                body['value'] = htmlparser.unescape(body['value'])
+                body['value'] = _unescape(body['value'])
                 log.debug("unescaped body: %s", body['value'])
 
             elif 'view' in body:
                 body = body['view']
                 log.debug("unescaped body")
-                body['value'] = htmlparser.unescape(body['value'])
+                body['value'] = _unescape(body['value'])
 
 
         if hasattr(expand, 'split'):


### PR DESCRIPTION
It seems that there is still an issue when using stream parameter for ct get command. Variable data is an bytestring but needs to be string for write function.